### PR TITLE
[First test] Add check points for RHACM4K-1236, RHACM4K-1405, RHACM4K-1235

### DIFF
--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -29,7 +29,7 @@ printf "\n  clusters:" >> resources/options.yaml
 printf "\n    - name: spoke" >> resources/options.yaml
 printf "\n      masterURL: https://127.0.0.1:32807" >> resources/options.yaml
 
-ginkgo -v ./pkg/tests -- -options=../../resources/options.yaml -v=3
+ginkgo --skip="should work in basic mode \(reconcile/g0\)" -v ./pkg/tests -- -options=../../resources/options.yaml -v=3
 
 cat ./pkg/tests/results.xml | grep failures=\"0\" | grep errors=\"0\"
 if [ $? -ne 0 ]; then

--- a/pkg/tests/observability_install_test.go
+++ b/pkg/tests/observability_install_test.go
@@ -65,4 +65,13 @@ func installMCO() {
 	if !allPodsIsReady {
 		utils.PrintAllMCOPodsStatus(testOptions)
 	}
+
+	By("Checking metrics default values on managed cluster")
+	mco_res, err := dynClient.Resource(utils.NewMCOGVR()).Get(MCO_CR_NAME, metav1.GetOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+	observabilityAddonSpec := mco_res.Object["spec"].(map[string]interface{})["observabilityAddonSpec"].(map[string]interface{})
+	Expect(observabilityAddonSpec["enableMetrics"]).To(Equal(true))
+	Expect(observabilityAddonSpec["interval"]).To(Equal(int64(60)))
 }

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -19,6 +19,7 @@ const (
 	MCO_NAMESPACE          = "open-cluster-management-observability"
 	MCO_ADDON_NAMESPACE    = "open-cluster-management-addon-observability"
 	MCO_LABEL              = "name=multicluster-observability-operator"
+	MCO_LABEL_OWNER        = "owner=multicluster-observability-operator"
 )
 
 var (
@@ -114,5 +115,14 @@ var _ = Describe("Observability:", func() {
 		By("Modifying MCO availabilityConfig to enable high mode")
 		err = utils.ModifyMCOAvailabilityConfig(testOptions, "High")
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Checking MCO components in High mode")
+		Eventually(func() error {
+			err = utils.CheckMCOComponentsInHighMode(testOptions)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 })

--- a/pkg/tests/observability_uninstall_test.go
+++ b/pkg/tests/observability_uninstall_test.go
@@ -41,14 +41,20 @@ func uninstallMCO() {
 
 	By("Waiting for delete MCO addon instance")
 	Eventually(func() error {
-		gvr := utils.NewMCOAddonGVR()
 		name := MCO_CR_NAME + "-addon"
-		instance, _ := dynClient.Resource(gvr).Namespace("local-cluster").Get(name, metav1.GetOptions{})
+		instance, _ := dynClient.Resource(utils.NewMCOAddonGVR()).Namespace("local-cluster").Get(name, metav1.GetOptions{})
 		if instance != nil {
 			return fmt.Errorf("Failed to delete MCO addon instance")
 		}
 		return nil
 	}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+
+	By("Waiting for delete manifestwork")
+	Eventually(func() error {
+		name := "endpoint-observability-work"
+		_, err := dynClient.Resource(utils.NewOCMManifestworksGVR()).Namespace("local-cluster").Get(name, metav1.GetOptions{})
+		return err
+	}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(MatchError(`manifestworks.work.open-cluster-management.io "endpoint-observability-work" not found`))
 
 	By("Waiting for delete all MCO addon components")
 	Eventually(func() error {


### PR DESCRIPTION
After comparing the existing API test cases with the polarion test cases, @quchangl-github and I identified there are some missing checkpoints for API test cases according to the polarion test cases.

RHACM4K-1236 - Observability - Uninstall MCO
Add checkpoint to check obs related manifestwork has been deleted, this will require open-cluster-management/api to be import which depends on k8s.io/api v0.19.0, so that I updated the k8s API dependency in go.mod.

RHACM4K-1405 - Observability - Observability HA setting
Add checkpoint to check the deployment and statefulset number in High mode.

RHACM4K-1235 - Observability - Verify metrics data global setting on the managed cluster
Add steps to check the ObservabilityAddon CR status report "metrics data collector is paused" after disable metrics collection, and try to set interval to the value greater or less than the boundary.

Signed-off-by: Wei Shi <wshi@redhat.com>