### PR TITLE
Remove observatorium-api pod manually in KinD cluster

### DIFF
--- a/pkg/tests/observability_cert_renew_test.go
+++ b/pkg/tests/observability_cert_renew_test.go
@@ -23,8 +23,9 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P1,Sev1,observability] should have metrics collector pod restart if cert secret re-generated (certrenew/g0)", func() {
-		By("Waiting for pods ready: observability-observatorium-observatorium-api, rbac-query-proxy, metrics-collector-deployment")
+		By("Waiting for pods ready: observability-observatorium-observatorium-api, metrics-collector-deployment")
 		collectorPodName := ""
+		apiPodName := ""
 		Eventually(func() bool {
 			if collectorPodName == "" {
 				_, podList := utils.GetPodList(testOptions, false, MCO_ADDON_NAMESPACE, "component=metrics-collector")
@@ -32,7 +33,13 @@ var _ = Describe("Observability:", func() {
 					collectorPodName = podList.Items[0].Name
 				}
 			}
-			if collectorPodName == "" {
+			if apiPodName == "" {
+				_, podList := utils.GetPodList(testOptions, true, MCO_NAMESPACE, "app.kubernetes.io/name=observatorium-api")
+				if podList != nil && len(podList.Items) > 0 {
+					apiPodName = podList.Items[0].Name
+				}
+			}
+			if collectorPodName == "" && apiPodName == "" {
 				return false
 			}
 			return true
@@ -41,6 +48,28 @@ var _ = Describe("Observability:", func() {
 		By("Deleting certificate secret to simulate certificate renew")
 		err := utils.DeleteCertSecret(testOptions)
 		Expect(err).ToNot(HaveOccurred())
+
+		if !utils.IsCanaryEnvironment(testOptions) {
+			//When a secret currently consumed in a volume is updated, projected keys are eventually updated as well. The kubelet checks whether the mounted secret is fresh on every periodic sync. However, the kubelet uses its local cache for getting the current value of the Secret. The type of the cache is configurable using the ConfigMapAndSecretChangeDetectionStrategy field in the KubeletConfiguration struct. A Secret can be either propagated by watch (default), ttl-based, or simply redirecting all requests directly to the API server. As a result, the total delay from the moment when the Secret is updated to the moment when new keys are projected to the Pod can be as long as the kubelet sync period + cache propagation delay, where the cache propagation delay depends on the chosen cache type (it equals to watch propagation delay, ttl of cache, or zero correspondingly).
+			// in KinD cluster, the observatorium-api won't be restarted, it may due to cert-manager webhook or the kubelet sync period + cache propagation delay
+			// so manually delete the pod to force it restart
+			utils.DeletePod(testOptions, true, MCO_NAMESPACE, apiPodName)
+		}
+
+		By(fmt.Sprintf("Waiting for old pod removed: %s", apiPodName))
+		Eventually(func() bool {
+			err, podList := utils.GetPodList(testOptions, true, MCO_NAMESPACE, "app.kubernetes.io/name=observatorium-api")
+			if err == nil {
+				for _, pod := range podList.Items {
+					if pod.Name == apiPodName {
+						return true
+					}
+				}
+			} else {
+				return true
+			}
+			return false
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(BeFalse())
 
 		By(fmt.Sprintf("Waiting for old pod removed: %s", collectorPodName))
 		Eventually(func() bool {

--- a/pkg/utils/mco_pods.go
+++ b/pkg/utils/mco_pods.go
@@ -21,3 +21,13 @@ func GetPodList(opt TestOptions, isHub bool, namespace string, labelSelector str
 	}
 	return err, podList
 }
+
+func DeletePod(opt TestOptions, isHub bool, namespace, name string) error {
+	clientKube := getKubeClient(opt, isHub)
+	err := clientKube.CoreV1().Pods(namespace).Delete(name, &metav1.DeleteOptions{})
+	if err != nil {
+		klog.Errorf("Failed to delete pod %s in namespace %s due to %v", name, namespace, err)
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
the `observatorium-api-xxx` pod won't be deleted after the secret deleted. it may due to cert-manager webhook or the kubelet sync period + cache propagation delay