### PR TITLE
Compact and shard are 1 instance

### DIFF
--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -358,6 +358,26 @@ func CheckMCOComponentsInHighMode(opt TestOptions) error {
 		}
 	}
 
+	expectedStatefulSetNames = []string{
+		"observability-observatorium-thanos-compact",
+		"observability-observatorium-thanos-store-shard-0",
+		"observability-observatorium-thanos-store-shard-1",
+		"observability-observatorium-thanos-store-shard-2",
+	}
+
+	for _, statefulsetName := range expectedStatefulSetNames {
+		statefulset, err := statefulsets.Get(statefulsetName, metav1.GetOptions{})
+		if err != nil {
+			klog.V(1).Infof("Error while retrieving statefulset %s: %s", statefulsetName, err.Error())
+			return err
+		}
+
+		if statefulset.Status.ReadyReplicas != 1 {
+			err = fmt.Errorf("Expect 1 but got %d ready replicas", statefulset.Status.ReadyReplicas)
+			return err
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
for High mode, shard has 3 sts and 1 instance per sts.
Compact is only 1 instance - https://thanos.io/tip/components/compact.md/#availability