### PR TITLE
fix observatorium cr revert test error

### DIFF
--- a/pkg/tests/observability_observatorium_preserve_test.go
+++ b/pkg/tests/observability_observatorium_preserve_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	Context("[P1][Sev1][Observability] Should revert any manual changes on observatorium cr (observatorium_preserve/g0) -", func() {
-		It("Updating observatorium cr", func() {
+		It("Updating observatorium cr (spec.rule.replicas) should be automatically reverted", func() {
 			crName := "observability-observatorium"
 			oldResourceVersion := ""
 			updateReplicas := int64(2)


### PR DESCRIPTION
In `High` mode, the rule replicas is `3`,  so we need to update it with a different value (2).  and in `Basic` mode, the rule replicas is `1`. so we can not use `1` to update its value. @shi2wei3 FYI.
