### PR TITLE
Set 	testFailed = true in beforeSuite

### DIFF
--- a/pkg/tests/observability-e2e-test_suite_test.go
+++ b/pkg/tests/observability-e2e-test_suite_test.go
@@ -91,8 +91,10 @@ func TestObservabilityE2E(t *testing.T) {
 var agoutiDriver *agouti.WebDriver
 
 var _ = BeforeSuite(func() {
+	testFailed = true
 	initVars()
 	installMCO()
+	testFailed = false
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Set `testFailed = true` at the beginning of `BeforeSuite`. Set it to false in the end. If the error occurs in `BeforeSuite`, do nothing in `AfterSuite` so that the failed environment can be kept.