### PR TITLE
fixed ginkgo version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY . /go/src/github.com/open-cluster-management/observability-e2e-test/
 WORKDIR "/go/src/github.com/open-cluster-management/observability-e2e-test/"
 
 # compile go tests in build image
-RUN go get -u github.com/onsi/ginkgo/ginkgo && ginkgo build ./pkg/tests/
+RUN go get github.com/onsi/ginkgo/ginkgo@v1.14.2 && ginkgo build ./pkg/tests/
 
 # create new docker image to hold built artifacts
 FROM registry.fedoraproject.org/fedora-minimal:32


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9236
Ginko have a new release. the skip test feature has changed in the new version. so we should use a fixed version for Ginko