### PR TITLE
Enable uninstall observability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ ENV GINKGO_NODES "1"
 ENV GINKGO_FLAGS=""
 ENV GINKGO_FOCUS=""
 ENV GINKGO_SKIP=""
-ENV SKIP_UNINSTALL_STEP="true"
 
 # install ginkgo into built image
 COPY --from=build /go/bin/ /usr/local/bin


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/9351
https://github.com/open-cluster-management/backlog/issues/9488

The detach cluster won't work if there has oba in managedcluster namespace. 
```
  - lastTransitionTime: "2021-02-18T03:50:28Z"
    message: 'Some content in the namespace has finalizers remaining: cluster.open-cluster-management.io/manifest-work-cleanup
      in 4 resource instances, observability.open-cluster-management.io/addon-cleanup
```
Cleanup the observability components if pass all test cases.