### PR TITLE
fix copy path and component image override issues.

### DIFF
--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -259,7 +259,7 @@ deploy_mco_operator() {
             $SED_COMMAND "s~image:.*$~image: $COMPONENT_REPO/multicluster-observability-operator:$LATEST_SNAPSHOT~g" deploy/operator.yaml
             # test the concrete component
             component_anno_name=`echo $component_name | sed 's/-/_/g'`
-            sed -i "/annotations.*/a \ \ \ \ mco-$component_anno_name-tag: ${1##*:}" ${ROOTDIR}/cicd-scripts/e2e-setup-manifests/templates/multiclusterobservability_cr.yaml
+            sed -i "/annotations.*/a \ \ \ \ mco-$component_anno_name-image: ${1}" ${ROOTDIR}/cicd-scripts/e2e-setup-manifests/templates/multiclusterobservability_cr.yaml
         fi
     else
         git clone --depth 1 https://github.com/open-cluster-management/multicluster-observability-operator.git

--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -250,9 +250,7 @@ deploy_mco_operator() {
             fi
         done
         if [[ $component_name == "multicluster-observability-operator" ]]; then
-            # copy the current multicluster-observability-operator commits to ROOTDIR for testing
-            cp -r ${ROOTDIR}/../../multicluster-observability-operator ${ROOTDIR}
-            cd multicluster-observability-operator/
+            cd ${ROOTDIR}/../multicluster-observability-operator/
             $SED_COMMAND "s~image:.*$~image: $1~g" deploy/operator.yaml
         else
             git clone --depth 1 https://github.com/open-cluster-management/multicluster-observability-operator.git


### PR DESCRIPTION
1. Fix copy issue during e2e test for MCO:
```
+ cp -r /go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test/../../multicluster-observability-operator /go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test
cp: cannot copy a directory, '/go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test/../../multicluster-observability-operator', into itself, '/go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test/multicluster-observability-operator'
```
2. Fix component image override issue, depends on https://github.com/open-cluster-management/multicluster-observability-operator/pull/393