### PR TITLE
Disable some tests temporarily

### DIFF
--- a/pkg/tests/observability_cert_renew_test.go
+++ b/pkg/tests/observability_cert_renew_test.go
@@ -57,15 +57,6 @@ var _ = Describe("Observability:", func() {
 		err := utils.DeleteCertSecret(testOptions)
 		Expect(err).ToNot(HaveOccurred())
 
-		if !utils.IsCanaryEnvironment(testOptions) {
-			//When a secret currently consumed in a volume is updated, projected keys are eventually updated as well. The kubelet checks whether the mounted secret is fresh on every periodic sync. However, the kubelet uses its local cache for getting the current value of the Secret. The type of the cache is configurable using the ConfigMapAndSecretChangeDetectionStrategy field in the KubeletConfiguration struct. A Secret can be either propagated by watch (default), ttl-based, or simply redirecting all requests directly to the API server. As a result, the total delay from the moment when the Secret is updated to the moment when new keys are projected to the Pod can be as long as the kubelet sync period + cache propagation delay, where the cache propagation delay depends on the chosen cache type (it equals to watch propagation delay, ttl of cache, or zero correspondingly).
-			// in KinD cluster, the observatorium-api won't be restarted, it may due to cert-manager webhook or the kubelet sync period + cache propagation delay
-			// so manually delete the pod to force it restart
-			for apiPodName := range apiPodsName {
-				utils.DeletePod(testOptions, true, MCO_NAMESPACE, apiPodName)
-			}
-		}
-
 		By(fmt.Sprintf("Waiting for old pods removed: %v and new pods created", apiPodsName))
 		Eventually(func() bool {
 			err, podList := utils.GetPodList(testOptions, true, MCO_NAMESPACE, "app.kubernetes.io/name=observatorium-api")

--- a/pkg/tests/observability_default_config_test.go
+++ b/pkg/tests/observability_default_config_test.go
@@ -4,8 +4,6 @@
 package tests
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -37,49 +35,50 @@ var _ = Describe("Observability:", func() {
 		Expect(observabilityAddonSpec["interval"]).To(Equal(int64(30)))
 	})
 
-	It("[P1][Sev1][Observability] Checking default value of PVC and StorageClass (config/g0)", func() {
-		mcoSC, err := dynClient.Resource(utils.NewMCOGVR()).Get(MCO_CR_NAME, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+	// TODO: @clyang82 need to renable it after moving to v1beta2
+	// It("[P1][Sev1][Observability] Checking default value of PVC and StorageClass (config/g0)", func() {
+	// 	mcoSC, err := dynClient.Resource(utils.NewMCOGVR()).Get(MCO_CR_NAME, metav1.GetOptions{})
+	// 	Expect(err).NotTo(HaveOccurred())
 
-		spec := mcoSC.Object["spec"].(map[string]interface{})
-		sizeInCR := spec["storageConfigObject"].(map[string]interface{})["statefulSetSize"].(string)
-		scInCR := spec["storageConfigObject"].(map[string]interface{})["statefulSetStorageClass"].(string)
+	// 	spec := mcoSC.Object["spec"].(map[string]interface{})
+	// 	sizeInCR := spec["storageConfigObject"].(map[string]interface{})["statefulSetSize"].(string)
+	// 	scInCR := spec["storageConfigObject"].(map[string]interface{})["statefulSetStorageClass"].(string)
 
-		scList, err := hubClient.StorageV1().StorageClasses().List(metav1.ListOptions{})
-		scMatch := false
-		defaultSC := ""
-		for _, sc := range scList.Items {
-			if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
-				defaultSC = sc.Name
-			}
-			if sc.Name == scInCR {
-				scMatch = true
-			}
-		}
-		expectedSC := defaultSC
-		if scMatch {
-			expectedSC = scInCR
-		}
+	// 	scList, err := hubClient.StorageV1().StorageClasses().List(metav1.ListOptions{})
+	// 	scMatch := false
+	// 	defaultSC := ""
+	// 	for _, sc := range scList.Items {
+	// 		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+	// 			defaultSC = sc.Name
+	// 		}
+	// 		if sc.Name == scInCR {
+	// 			scMatch = true
+	// 		}
+	// 	}
+	// 	expectedSC := defaultSC
+	// 	if scMatch {
+	// 		expectedSC = scInCR
+	// 	}
 
-		Eventually(func() error {
-			pvcList, err := hubClient.CoreV1().PersistentVolumeClaims(MCO_NAMESPACE).List(metav1.ListOptions{})
-			if err != nil {
-				return err
-			}
-			for _, pvc := range pvcList.Items {
-				//for KinD cluster, we use minio as object storage. the size is 1Gi.
-				if pvc.GetName() != "minio" {
-					pvcSize := pvc.Spec.Resources.Requests["storage"]
-					scName := *pvc.Spec.StorageClassName
-					statusPhase := pvc.Status.Phase
-					if pvcSize.String() != sizeInCR || scName != expectedSC || statusPhase != "Bound" {
-						return fmt.Errorf("PVC check failed, pvcSize = %s, sizeInCR = %s, scName = %s, expectedSC = %s, statusPhase = %s", pvcSize.String(), sizeInCR, scName, expectedSC, statusPhase)
-					}
-				}
-			}
-			return nil
-		}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*5).Should(Succeed())
-	})
+	// 	Eventually(func() error {
+	// 		pvcList, err := hubClient.CoreV1().PersistentVolumeClaims(MCO_NAMESPACE).List(metav1.ListOptions{})
+	// 		if err != nil {
+	// 			return err
+	// 		}
+	// 		for _, pvc := range pvcList.Items {
+	// 			//for KinD cluster, we use minio as object storage. the size is 1Gi.
+	// 			if pvc.GetName() != "minio" {
+	// 				pvcSize := pvc.Spec.Resources.Requests["storage"]
+	// 				scName := *pvc.Spec.StorageClassName
+	// 				statusPhase := pvc.Status.Phase
+	// 				if pvcSize.String() != sizeInCR || scName != expectedSC || statusPhase != "Bound" {
+	// 					return fmt.Errorf("PVC check failed, pvcSize = %s, sizeInCR = %s, scName = %s, expectedSC = %s, statusPhase = %s", pvcSize.String(), sizeInCR, scName, expectedSC, statusPhase)
+	// 				}
+	// 			}
+	// 		}
+	// 		return nil
+	// 	}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*5).Should(Succeed())
+	// })
 
 	AfterEach(func() {
 		if testFailed {

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -93,20 +93,24 @@ var _ = Describe("Observability:", func() {
 		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
-	It("[P1][Sev1][Observability] Revert MCO CR changes (reconcile/g0)", func() {
-		By("Revert MCO CR changes")
-		err := utils.RevertMCOCRModification(testOptions)
-		Expect(err).ToNot(HaveOccurred())
+	// TODO: clyang82 add it back.
+	// It("[P1][Sev1][Observability] Revert MCO CR changes (reconcile/g0)", func() {
+	// 	if !utils.IsCanaryEnvironment(testOptions) {
+	// 		Skip("should skip the high basic mode (reconcile/g0)")
+	// 	}
+	// 	By("Revert MCO CR changes")
+	// 	err := utils.RevertMCOCRModification(testOptions)
+	// 	Expect(err).ToNot(HaveOccurred())
 
-		By("Checking MCO components in default HA mode")
-		Eventually(func() error {
-			err = utils.CheckMCOComponentsInHighMode(testOptions)
-			if err != nil {
-				return err
-			}
-			return nil
-		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
-	})
+	// 	By("Checking MCO components in default HA mode")
+	// 	Eventually(func() error {
+	// 		err = utils.CheckMCOComponentsInHighMode(testOptions)
+	// 		if err != nil {
+	// 			return err
+	// 		}
+	// 		return nil
+	// 	}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
+	// })
 
 	AfterEach(func() {
 		if testFailed {

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -4,12 +4,10 @@
 package tests
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 
@@ -54,34 +52,24 @@ var _ = Describe("Observability:", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("[P1][Sev1][Observability] Checking MCO components in Basic mode (reconcile/g0)", func() {
-		By("Checking MCO components in Basic mode")
-		Eventually(func() error {
-			err = utils.CheckMCOComponentsInBaiscMode(testOptions)
-			if err != nil {
-				return err
-			}
-			return nil
-		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
-	})
-
-	It("[P1][Sev1][Observability] Modifying retentionResolutionRaw (reconcile/g0)", func() {
-		By("Waiting for MCO retentionResolutionRaw filed to take effect")
-		Eventually(func() error {
-			name := MCO_CR_NAME + "-thanos-compact"
-			compact, getError := hubClient.AppsV1().StatefulSets(MCO_NAMESPACE).Get(name, metav1.GetOptions{})
-			if getError != nil {
-				return getError
-			}
-			argList := compact.Spec.Template.Spec.Containers[0].Args
-			for _, arg := range argList {
-				if arg == "--retention.resolution-raw=3d" {
-					return nil
-				}
-			}
-			return fmt.Errorf("Failed to find modified retention field")
-		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
-	})
+	// TODO: clyang82 add it back after moving to v1beta2
+	// It("[P1][Sev1][Observability] Modifying retentionResolutionRaw (reconcile/g0)", func() {
+	// 	By("Waiting for MCO retentionResolutionRaw filed to take effect")
+	// 	Eventually(func() error {
+	// 		name := MCO_CR_NAME + "-thanos-compact"
+	// 		compact, getError := hubClient.AppsV1().StatefulSets(MCO_NAMESPACE).Get(name, metav1.GetOptions{})
+	// 		if getError != nil {
+	// 			return getError
+	// 		}
+	// 		argList := compact.Spec.Template.Spec.Containers[0].Args
+	// 		for _, arg := range argList {
+	// 			if arg == "--retention.resolution-raw=3d" {
+	// 				return nil
+	// 			}
+	// 		}
+	// 		return fmt.Errorf("Failed to find modified retention field")
+	// 	}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+	// })
 
 	It("[P1][Sev1][Observability] Checking node selector for all pods (reconcile/g0)", func() {
 		By("Checking node selector for all pods")
@@ -106,14 +94,11 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P1][Sev1][Observability] Revert MCO CR changes (reconcile/g0)", func() {
-		if !utils.IsCanaryEnvironment(testOptions) {
-			Skip("should skip the high basic mode (reconcile/g0)")
-		}
 		By("Revert MCO CR changes")
 		err := utils.RevertMCOCRModification(testOptions)
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Checking MCO components in High mode")
+		By("Checking MCO components in default HA mode")
 		Eventually(func() error {
 			err = utils.CheckMCOComponentsInHighMode(testOptions)
 			if err != nil {

--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -445,9 +445,9 @@ func ModifyMCOCR(opt TestOptions) error {
 		return getErr
 	}
 	spec := mco.Object["spec"].(map[string]interface{})
-	spec["retentionResolutionRaw"] = "3d"
+	//TODO: @clyang82 add it back after moving to v1beta2
+	//spec["retentionResolutionRaw"] = "3d"
 	spec["nodeSelector"] = map[string]string{"kubernetes.io/os": "linux"}
-	spec["availabilityConfig"] = "Basic"
 
 	_, updateErr := clientDynamic.Resource(NewMCOGVR()).Update(mco, metav1.UpdateOptions{})
 	if updateErr != nil {
@@ -467,11 +467,11 @@ func RevertMCOCRModification(opt TestOptions) error {
 		return getErr
 	}
 	spec := mco.Object["spec"].(map[string]interface{})
-	spec["retentionResolutionRaw"] = "5d"
+	//spec["retentionResolutionRaw"] = "5d"
 	spec["nodeSelector"] = map[string]string{}
 	if IsCanaryEnvironment(opt) {
 		//KinD cluster does not have enough resource to support High mode
-		spec["availabilityConfig"] = "High"
+		//spec["availabilityConfig"] = "High"
 	}
 
 	_, updateErr := clientDynamic.Resource(NewMCOGVR()).Update(mco, metav1.UpdateOptions{})

--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -469,10 +469,6 @@ func RevertMCOCRModification(opt TestOptions) error {
 	spec := mco.Object["spec"].(map[string]interface{})
 	//spec["retentionResolutionRaw"] = "5d"
 	spec["nodeSelector"] = map[string]string{}
-	if IsCanaryEnvironment(opt) {
-		//KinD cluster does not have enough resource to support High mode
-		//spec["availabilityConfig"] = "High"
-	}
 
 	_, updateErr := clientDynamic.Resource(NewMCOGVR()).Update(mco, metav1.UpdateOptions{})
 	if updateErr != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -572,12 +572,3 @@ func IsOpenshift(client *rest.RESTClient) bool {
 	klog.V(5).Infof("fail to GET openshift version, assuming not OpenShift: %s", err.Error())
 	return false
 }
-
-// IsCanaryEnvironment returns true for canary enviornment. return false for kind environment
-func IsCanaryEnvironment(testOptions TestOptions) bool {
-	if testOptions.HubCluster.BaseDomain != "placeholder" {
-		return true
-	} else {
-		return false
-	}
-}


### PR DESCRIPTION
Some properties are expired in v1beta2. for example: `availabilityConfig`. disable temporarily to make e2e test pass for v1beta2. Will re-enable it soon.

Signed-off-by: clyang82 <chuyang@redhat.com>