### PR TITLE
Revert RHACM4K-1449 dc32f10

### DIFF
--- a/pkg/tests/observability_metricslist_test.go
+++ b/pkg/tests/observability_metricslist_test.go
@@ -64,7 +64,6 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P1][Sev1][Observability] Should have metrics which defined in metrics allowlist (metricslist/g0)", func() {
-		Skip("Skip the test for default metrics allowlist")
 		runDuration := 30
 		runCount := 30
 

--- a/pkg/utils/mco_metric.go
+++ b/pkg/utils/mco_metric.go
@@ -5,7 +5,6 @@ package utils
 
 import (
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -14,71 +13,6 @@ import (
 
 	"k8s.io/klog"
 )
-
-func GetPrometheusURL(opt TestOptions) string {
-	prometheusURL := "https://prometheus-k8s-openshift-monitoring.apps." + opt.HubCluster.BaseDomain
-	return prometheusURL
-}
-
-func GetPrometheusMetricsMetadata(opt TestOptions) (error, []string) {
-	prometheusURL := GetPrometheusURL(opt)
-	path := "/api/v1/metadata"
-	klog.V(1).Infof("request url is: %s\n", prometheusURL+path)
-	req, err := http.NewRequest(
-		"GET",
-		prometheusURL+path,
-		nil)
-	if err != nil {
-		return err, nil
-	}
-
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-
-	client := &http.Client{Transport: tr}
-	token, err := FetchBearerToken(opt)
-	if err != nil {
-		return err, nil
-	}
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	req.Host = opt.HubCluster.GrafanaHost
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err, nil
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		klog.Errorf("resp.StatusCode: %v\n", resp.StatusCode)
-		return fmt.Errorf("Failed to access prometheus metrics metadata"), nil
-	}
-
-	metricResult, err := ioutil.ReadAll(resp.Body)
-	klog.V(1).Infof("queryResult: %s\n", metricResult)
-	if err != nil {
-		return err, nil
-	}
-
-	if !strings.Contains(string(metricResult), `"status":"success"`) {
-		return fmt.Errorf("Failed to find valid status from response"), nil
-	}
-
-	metaData := make(map[string]interface{})
-
-	err = json.Unmarshal([]byte(metricResult), &metaData)
-
-	data := metaData["data"].(map[string]interface{})
-
-	names := make([]string, 0, len(data))
-	for k := range data {
-		names = append(names, k)
-	}
-
-	return nil, names
-}
 
 func ContainManagedClusterMetric(opt TestOptions, query string, matchedLabels []string) (error, bool) {
 	grafanaConsoleURL := GetGrafanaURL(opt)


### PR DESCRIPTION
Revert the following commits
dc32f10 2021-03-23 | Add test case for RHACM4K-1449 (#120) (tag: v2.3.0-2021-03-23-10-36-07) [Wei Shi]
59e6ba6 2021-03-24 | disable the test for default allow list temporarily (#132) (tag: v2.3.0-2021-03-25-01-47-24) [Ling Lan]

This test case is not needed because a single hardcore metrics test could be enough, no need to test all of them due to obs doesn't have code snip or path do handle each metrics.