### PR TITLE
Add cases for replicas and storage resize

### DIFF
--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -104,6 +104,35 @@ var _ = Describe("Observability:", func() {
 		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
+	It("[P2][Sev2][Observability] Checking alertmanager storage resize (reconcile/g0)", func() {
+		By("Resizing alertmanager storage")
+		Eventually(func() error {
+			err := utils.CheckStorageResize(testOptions)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+	})
+
+	It("[P2][Sev2][Observability] Customize the replicas for thanos query (reconcile/g0)", func() {
+		Eventually(func() error {
+			err := utils.UpdateDeploymentReplicas(testOptions, MCO_CR_NAME+"-thanos-query", "query", 3, 3)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+
+		Eventually(func() error {
+			err := utils.UpdateDeploymentReplicas(testOptions, MCO_CR_NAME+"-thanos-query", "query", 0, 3)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+	})
+
 	It("[P2][Sev2][Observability] Revert MCO CR changes (reconcile/g0)", func() {
 
 		By("Revert MCO CR changes")

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -52,9 +52,7 @@ var _ = Describe("Observability:", func() {
 		By("Modifying MCO CR for reconciling")
 		err := utils.ModifyMCOCR(testOptions)
 		Expect(err).ToNot(HaveOccurred())
-	})
 
-	It("[P2][Sev2][Observability] Modifying retentionResolutionRaw (reconcile/g0)", func() {
 		By("Waiting for MCO retentionResolutionRaw filed to take effect")
 		Eventually(func() error {
 			name := MCO_CR_NAME + "-thanos-compact"
@@ -70,6 +68,7 @@ var _ = Describe("Observability:", func() {
 			}
 			return fmt.Errorf("Failed to find modified retention field")
 		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+
 		By("Wait for thanos compact pods are ready")
 		// ensure the thanos rule pods are restarted successfully before processing
 		Eventually(func() error {
@@ -80,6 +79,15 @@ var _ = Describe("Observability:", func() {
 			return nil
 		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
 
+		By("Wait for alertmanager pods are ready")
+		// ensure the thanos rule pods are restarted successfully before processing
+		Eventually(func() error {
+			err = utils.CheckStatefulSetPodReady(testOptions, MCO_CR_NAME+"-alertmanager", 3)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	It("[P2][Sev2][Observability] Checking node selector for all pods (reconcile/g0)", func() {
@@ -139,6 +147,16 @@ var _ = Describe("Observability:", func() {
 			}
 			return nil
 		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+
+		By("Wait for thanos query pods are ready")
+		Eventually(func() error {
+			err = utils.CheckDeploymentPodReady(testOptions, MCO_CR_NAME+"-thanos-query", 2)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
+
 	})
 
 	It("[P2][Sev2][Observability] Revert MCO CR changes (reconcile/g0)", func() {
@@ -146,6 +164,22 @@ var _ = Describe("Observability:", func() {
 		By("Revert MCO CR changes")
 		err := utils.RevertMCOCRModification(testOptions)
 		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for MCO retentionResolutionRaw filed to take effect")
+		Eventually(func() error {
+			name := MCO_CR_NAME + "-thanos-compact"
+			compact, err := hubClient.AppsV1().StatefulSets(MCO_NAMESPACE).Get(name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			argList := compact.Spec.Template.Spec.Containers[0].Args
+			for _, arg := range argList {
+				if arg == "--retention.resolution-raw=5d" {
+					return nil
+				}
+			}
+			return fmt.Errorf("Failed to find modified retention field")
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 
 		By("Wait for thanos compact pods are ready")
 		// ensure the thanos rule pods are restarted successfully before processing

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -131,6 +131,14 @@ var _ = Describe("Observability:", func() {
 			}
 			return nil
 		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
+
+		Eventually(func() error {
+			err := utils.UpdateDeploymentReplicas(testOptions, MCO_CR_NAME+"-thanos-query", "query", 2, 2)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	It("[P2][Sev2][Observability] Revert MCO CR changes (reconcile/g0)", func() {

--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -264,8 +264,8 @@ func CheckStorageResize(opt TestOptions) error {
 		return err
 	}
 	vct := statefulset.Spec.VolumeClaimTemplates[0]
-	if vct.Spec.Resources.Requests["storage"].Equal(resource.MustParse("2Gi")) {
-		err = fmt.Errorf("the storage size of statefulset %s should have %v but got %d",
+	if !vct.Spec.Resources.Requests["storage"].Equal(resource.MustParse("2Gi")) {
+		err = fmt.Errorf("the storage size of statefulset %s should have %s but got %v",
 			MCO_CR_NAME+"-alertmanager", "2Gi",
 			vct.Spec.Resources.Requests["storage"])
 		return err

--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -373,9 +373,32 @@ func CheckStatefulSetPodReady(opt TestOptions, stsName string, number int32) err
 	if statefulset.Status.ReadyReplicas != number ||
 		statefulset.Status.UpdatedReplicas != number ||
 		statefulset.Status.UpdateRevision != statefulset.Status.CurrentRevision {
-		err = fmt.Errorf("Statefulset %s should have 3 but got %d ready replicas",
-			stsName,
+		err = fmt.Errorf("Statefulset %s should have %d but got %d ready replicas",
+			stsName, number,
 			statefulset.Status.ReadyReplicas)
+		return err
+	}
+	return nil
+}
+
+func CheckDeploymentPodReady(opt TestOptions, deployName string, number int32) error {
+	client := NewKubeClient(
+		opt.HubCluster.MasterURL,
+		opt.KubeConfig,
+		opt.HubCluster.KubeContext)
+	deploys := client.AppsV1().Deployments(MCO_NAMESPACE)
+	deploy, err := deploys.Get(deployName, metav1.GetOptions{})
+	if err != nil {
+		klog.V(1).Infof("Error while retrieving statefulset %s: %s", deployName, err.Error())
+		return err
+	}
+
+	if deploy.Status.ReadyReplicas != number ||
+		deploy.Status.UpdatedReplicas != number ||
+		deploy.Status.AvailableReplicas != number {
+		err = fmt.Errorf("Statefulset %s should have %d but got %d ready replicas",
+			deployName, number,
+			deploy.Status.ReadyReplicas)
 		return err
 	}
 	return nil

--- a/pkg/utils/mco_deployments.go
+++ b/pkg/utils/mco_deployments.go
@@ -4,6 +4,8 @@
 package utils
 
 import (
+	"errors"
+
 	appv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
@@ -36,4 +38,26 @@ func UpdateDeployment(opt TestOptions, isHub bool, name string, namespace string
 		klog.Errorf("Failed to update deployment %s in namespace %s due to %v", name, namespace, err)
 	}
 	return err, updateDep
+}
+
+func UpdateDeploymentReplicas(opt TestOptions, deployName, crProperty string, desiredReplicas, expectedReplicas int32) error {
+	clientDynamic := GetKubeClientDynamic(opt, true)
+	err, deploy := GetDeployment(opt, true, deployName, MCO_NAMESPACE)
+	if err != nil {
+		return err
+	}
+	deploy.Spec.Replicas = &desiredReplicas
+	UpdateDeployment(opt, true, deployName, MCO_NAMESPACE, deploy)
+
+	obs, err := clientDynamic.Resource(NewMCOMObservatoriumGVR()).Namespace(MCO_NAMESPACE).Get(MCO_CR_NAME, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	thanos := obs.Object["spec"].(map[string]interface{})["thanos"]
+	currentReplicas := thanos.(map[string]interface{})[crProperty].(map[string]interface{})["replicas"]
+	if currentReplicas != &expectedReplicas {
+		klog.Errorf("Failed to update deployment %s replicas to %v", deployName, expectedReplicas)
+		return errors.New("The replicas was not updated successfully")
+	}
+	return nil
 }

--- a/pkg/utils/mco_deployments.go
+++ b/pkg/utils/mco_deployments.go
@@ -54,8 +54,8 @@ func UpdateDeploymentReplicas(opt TestOptions, deployName, crProperty string, de
 		return err
 	}
 	thanos := obs.Object["spec"].(map[string]interface{})["thanos"]
-	currentReplicas := thanos.(map[string]interface{})[crProperty].(map[string]interface{})["replicas"]
-	if currentReplicas != &expectedReplicas {
+	currentReplicas := thanos.(map[string]interface{})[crProperty].(map[string]interface{})["replicas"].(int64)
+	if int(currentReplicas) != int(expectedReplicas) {
 		klog.Errorf("Failed to update deployment %s replicas to %v", deployName, expectedReplicas)
 		return errors.New("The replicas was not updated successfully")
 	}


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/8803

Add the following cases:
1. resize the alertmanager storage size
2. update the replicas for thanos-query from 2 to 3. the expected result is 3.
3. update  the replicas for thanos-query from 3 to 0. the expected result is 3.
4. 3. update  the replicas for thanos-query from 3 to 2. the expected result is 2.

Signed-off-by: clyang82 <chuyang@redhat.com>