### PR TITLE
Ensure all required components are ready

### DIFF
--- a/pkg/tests/observability_install_test.go
+++ b/pkg/tests/observability_install_test.go
@@ -98,14 +98,12 @@ func installMCO() {
 	By("Waiting for MCO ready status")
 	allPodsIsReady = false
 	Eventually(func() error {
-		instance, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
-		if err == nil {
-			allPodsIsReady = utils.StatusContainsTypeEqualTo(instance, "Ready")
-			if allPodsIsReady {
-				return nil
-			}
+		err = utils.CheckMCOComponentsInHighMode(testOptions)
+		if err != nil {
+			return err
 		}
-		return fmt.Errorf("MCO componnets cannot be running in 20 minutes. check the MCO CR status for the details: %v", instance.Object["status"])
+		allPodsIsReady = true
+		return nil
 	}, EventuallyTimeoutMinute*20, EventuallyIntervalSecond*5).Should(Succeed())
 
 	if !allPodsIsReady {

--- a/pkg/tests/observability_observatorium_preserve_test.go
+++ b/pkg/tests/observability_observatorium_preserve_test.go
@@ -4,6 +4,8 @@
 package tests
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +53,9 @@ var _ = Describe("Observability:", func() {
 				}
 				return false
 			}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*1).Should(BeTrue())
+
+			// wait for pod restarting
+			time.Sleep(10 * time.Second)
 
 			By("Wait for thanos compact pods are ready")
 			// ensure the thanos rule pods are restarted successfully before processing


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/11239

for the second time, the MCO CR status won't be updated. in other words, the MCO CR status is always ready after the first time. so we need to ensure all the components are ready before go to next step.

Signed-off-by: clyang82 <chuyang@redhat.com>