### PR TITLE
Improve the tests

### DIFF
--- a/pkg/tests/observability_addon_test.go
+++ b/pkg/tests/observability_addon_test.go
@@ -208,6 +208,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -215,6 +216,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_alert_test.go
+++ b/pkg/tests/observability_alert_test.go
@@ -191,6 +191,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -198,6 +199,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_cert_renew_test.go
+++ b/pkg/tests/observability_cert_renew_test.go
@@ -110,6 +110,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -117,6 +118,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_custom_dashboards_test.go
+++ b/pkg/tests/observability_custom_dashboards_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Observability:", func() {
 		}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*5).Should(BeTrue())
 	})
 
-	It("[P2][Sev2][Observability][Stable] Should have no custom dashboard in grafana after related configmap removed (dashboard/g0)", func() {
+	It("[P2][Sev2][Observability][Integration] Should have no custom dashboard in grafana after related configmap removed (dashboard/g0)", func() {
 		By("Deleting custom dashboard configmap")
 		err = utils.DeleteConfigMap(testOptions, true, dashboardName, MCO_NAMESPACE)
 		Expect(err).ToNot(HaveOccurred())
@@ -65,6 +65,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -72,6 +73,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_default_config_test.go
+++ b/pkg/tests/observability_default_config_test.go
@@ -80,6 +80,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -87,6 +88,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_endpoint_preserve_test.go
+++ b/pkg/tests/observability_endpoint_preserve_test.go
@@ -140,6 +140,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -147,6 +148,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_grafana_dev_test.go
+++ b/pkg/tests/observability_grafana_dev_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -37,6 +38,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_grafana_test.go
+++ b/pkg/tests/observability_grafana_test.go
@@ -31,6 +31,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -38,6 +39,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_manifestwork_test.go
+++ b/pkg/tests/observability_manifestwork_test.go
@@ -96,6 +96,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -103,6 +104,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_metricslist_test.go
+++ b/pkg/tests/observability_metricslist_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -64,6 +65,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_observatorium_preserve_test.go
+++ b/pkg/tests/observability_observatorium_preserve_test.go
@@ -70,6 +70,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -77,6 +78,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -202,6 +202,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
@@ -209,6 +210,5 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })


### PR DESCRIPTION
1. Print the cr/pod information if the current case is failed
2. Move `P2][Sev2][Observability][Integration] Should have no custom dashboard in grafana after related configmap removed (dashboard/g0)` to integration stage since we found this case is not stable enough.

https://github.com/open-cluster-management/backlog/issues/11833

Signed-off-by: clyang82 <chuyang@redhat.com>