### PR TITLE
increase timeout to waiting for metrics-collector ready

### DIFF
--- a/pkg/tests/observability_addon_test.go
+++ b/pkg/tests/observability_addon_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Observability:", func() {
 					return true
 				}
 				return false
-			}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*5).Should(BeTrue())
+			}, EventuallyTimeoutMinute*6, EventuallyIntervalSecond*5).Should(BeTrue())
 
 			By("Checking the status in managedclusteraddon reflects the endpoint operator status correctly")
 			if clusterName != "" {

--- a/pkg/tests/observability_grafana_test.go
+++ b/pkg/tests/observability_grafana_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Observability:", func() {
 		Eventually(func() error {
 			err, _ = utils.ContainManagedClusterMetric(testOptions, "node_memory_MemAvailable_bytes", []string{`"__name__":"node_memory_MemAvailable_bytes"`})
 			return err
-		}, EventuallyTimeoutMinute*3, EventuallyIntervalSecond*5).Should(Succeed())
+		}, EventuallyTimeoutMinute*6, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
To check the e2e test log,  it should be a timeout issue. so we should increase the timeout to waiting for metrics-collector ready.

https://github.com/open-cluster-management/backlog/issues/11951
Signed-off-by: Song Song Li <ssli@redhat.com>