### PR TITLE
Correct the chain command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ VOLUME /results
 WORKDIR "/opt/tests/"
 
 # execute compiled ginkgo tests
-CMD ["/bin/bash", "-c", "ginkgo --v --focus=${GINKGO_FOCUS} --skip=${GINKGO_SKIP} -nodes=${GINKGO_NODES} --reportFile=${REPORT_FILE} -x -debug -trace observability-e2e-test.test -- -v=3 && ./format-results.sh ${REPORT_FILE}"]
+CMD ["/bin/bash", "-c", "ginkgo --v --focus=${GINKGO_FOCUS} --skip=${GINKGO_SKIP} -nodes=${GINKGO_NODES} --reportFile=${REPORT_FILE} -x -debug -trace observability-e2e-test.test -- -v=3 ; ./format-results.sh ${REPORT_FILE}"]


### PR DESCRIPTION
Correct the chain command to ensure the `format-results.sh` can be executed even if the first command is failed.
https://github.com/open-cluster-management/backlog/issues/12054

Signed-off-by: clyang82 <chuyang@redhat.com>