### PR TITLE
add deleted metrics test

### DIFF
--- a/pkg/tests/observability_metricslist_test.go
+++ b/pkg/tests/observability_metricslist_test.go
@@ -42,6 +42,14 @@ var _ = Describe("Observability:", func() {
 		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
+	It("[P2][Sev2][Observability][Integration] Should have not metrics which have been marked for deletion (metricslist/g0)", func() {
+		By("Waiting for deleted metrics disappear on grafana console")
+		Eventually(func() error {
+			err, _ := utils.ContainManagedClusterMetric(testOptions, "rest_client_requests_total offset 1m", []string{`"__name__":"rest_client_requests_total"`})
+			return err
+		}, EventuallyTimeoutMinute*10, EventuallyIntervalSecond*5).Should(MatchError("Failed to find metric name from response"))
+	})
+
 	It("[P2][Sev2][Observability][Stable] Should have no metrics after custom metrics allowlist deleted (metricslist/g0)", func() {
 		By("Deleting custom metrics allowlist configmap")
 		Eventually(func() error {


### PR DESCRIPTION
if a metric name ending in `-`,  we will delete this metric from the default allowlist.

https://github.com/open-cluster-management/backlog/issues/12106

depend on https://github.com/open-cluster-management/observability-gitops/pull/21 and https://github.com/open-cluster-management/multicluster-observability-operator/pull/513

Signed-off-by: Song Song Li <ssli@redhat.com>