### PR TITLE
Fix panic

### DIFF
--- a/pkg/tests/observability_install_test.go
+++ b/pkg/tests/observability_install_test.go
@@ -80,7 +80,11 @@ func installMCO() {
 					return nil
 				}
 			}
-			return fmt.Errorf("MCO componnets cannot be running in 20 minutes. check the MCO CR status for the details: %v", instance.Object["status"])
+			if instance != nil && instance.Object != nil {
+				return fmt.Errorf("MCO componnets cannot be running in 20 minutes. check the MCO CR status for the details: %v", instance.Object["status"])
+			} else {
+				return fmt.Errorf("Wait for reconciling.")
+			}
 		}, EventuallyTimeoutMinute*20, EventuallyIntervalSecond*5).Should(Succeed())
 
 		By("Check clustermanagementaddon CR is created")


### PR DESCRIPTION
fix the panic error in e2e tests. need to ensure `instance` and `instance.Object` exist before using it.
```
[1mSTEP[0m: Waiting for MCO ready status
[91m[1mPanic [12.414 seconds][0m
[91m[1m[BeforeSuite] BeforeSuite [0m
[37m/go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test/pkg/tests/observability-e2e-test_suite_test.go:95[0m

  [91m[1mTest Panicked[0m
  [91mruntime error: invalid memory address or nil pointer dereference[0m
  /usr/local/go/src/runtime/panic.go:212

  [91mFull Stack Trace[0m
  github.com/open-cluster-management/observability-e2e-test/pkg/tests.installMCO.func2(0x0, 0x0)
  	/go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test/pkg/tests/observability_install_test.go:83 +0x121
  reflect.Value.call(0x1d466e0, 0xc00065c440, 0x13, 0x1f88b65, 0x4, 0xc0000dc778, 0x0, 0x0, 0x1d466e0, 0x1, ...)
  	/usr/local/go/src/reflect/value.go:476 +0x8c7
  reflect.Value.Call(0x1d466e0, 0xc00065c440, 0x13, 0xc0000dc778, 0x0, 0x0, 0xc0000dc8c8, 0xc0023ae2a0, 0xc0023ae2a0)
  	/usr/local/go/src/reflect/value.go:337 +0xb9
  github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).pollActual(0xc00077e0c0, 0xc0000dc840, 0x2, 0x0, 0x1)
  	/go/pkg/mod/github.com/onsi/gomega@v1.10.1/internal/asyncassertion/async_assertion.go:78 +0xee
  github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).match(0xc00077e0c0, 0x21966c0, 0x2e82a88, 0x12a05f201, 0x0, 0x0, 0x0, 0x989680)
  	/go/pkg/mod/github.com/onsi/gomega@v1.10.1/internal/asyncassertion/async_assertion.go:150 +0x308
  github.com/onsi/gomega/internal/asyncassertion.(*AsyncAssertion).Should(0xc00077e0c0, 0x21966c0, 0x2e82a88, 0x0, 0x0, 0x0, 0x216c700)
  	/go/pkg/mod/github.com/onsi/gomega@v1.10.1/internal/asyncassertion/async_assertion.go:51 +0x85
  github.com/open-cluster-management/observability-e2e-test/pkg/tests.installMCO()
  	/go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test/pkg/tests/observability_install_test.go:84 +0x1042
  github.com/open-cluster-management/observability-e2e-test/pkg/tests.glob..func1()
  	/go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test/pkg/tests/observability-e2e-test_suite_test.go:98 +0x2c
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc000598120, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
  	/go/pkg/mod/github.com/onsi/ginkgo@v1.16.2/internal/leafnodes/runner.go:113 +0xa3
  github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0xc000598120, 0x1e8ea07, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
  	/go/pkg/mod/github.com/onsi/ginkgo@v1.16.2/internal/leafnodes/runner.go:64 +0x15c
  github.com/onsi/ginkgo/internal/leafnodes.(*simpleSuiteNode).Run(0xc0001e5400, 0x1, 0x1, 0x0, 0x0, 0x2)
  	/go/pkg/mod/github.com/onsi/ginkgo@v1.16.2/internal/leafnodes/suite_nodes.go:25 +0x8f
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runBeforeSuite(0xc000168000, 0x0)
  	/go/pkg/mod/github.com/onsi/ginkgo@v1.16.2/internal/specrunner/spec_runner.go:123 +0xff
  github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run(0xc000168000, 0xc000490f00)
  	/go/pkg/mod/github.com/onsi/ginkgo@v1.16.2/internal/specrunner/spec_runner.go:63 +0xab
  github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0xc0001829a0, 0x7f0a4429f730, 0xc000001c80, 0x1fa12af, 0x17, 0xc00013ee00, 0x2, 0x2, 0x21aef40, 0xc0001109c0, ...)
  	/go/pkg/mod/github.com/onsi/ginkgo@v1.16.2/internal/suite/suite.go:79 +0x586
  github.com/onsi/ginkgo.runSpecsWithCustomReporters(0x2164a60, 0xc000001c80, 0x1fa12af, 0x17, 0xc00013ede0, 0x2, 0x2, 0x2)
  	/go/pkg/mod/github.com/onsi/ginkgo@v1.16.2/ginkgo_dsl.go:238 +0x238
  github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters(0x2164a60, 0xc000001c80, 0x1fa12af, 0x17, 0xc00008df60, 0x1, 0x1, 0xc00008df70)
  	/go/pkg/mod/github.com/onsi/ginkgo@v1.16.2/ginkgo_dsl.go:221 +0x145
  github.com/open-cluster-management/observability-e2e-test/pkg/tests.TestObservabilityE2E(0xc000001c80)
  	/go/src/github.com/open-cluster-management/multicluster-observability-operator/observability-e2e-test/pkg/tests/observability-e2e-test_suite_test.go:90 +0x119
  testing.tRunner(0xc000001c80, 0x2044548)
  	/usr/local/go/src/testing/testing.go:1123 +0xef
  created by testing.(*T).Run
  	/usr/local/go/src/testing/testing.go:1168 +0x2b3
[90m------------------------------[0m

```

Signed-off-by: clyang82 <chuyang@redhat.com>