### PR TITLE
Do not hard code the nodeSelector

### DIFF
--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -91,9 +91,18 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P2][Sev2][Observability][Stable] Checking node selector for all pods (reconcile/g0)", func() {
+		By("Checking node selector spec in MCO CR")
+		mcoSC, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		spec := mcoSC.Object["spec"].(map[string]interface{})
+		if _, ok := spec["nodeSelector"]; !ok {
+			Skip("Skip the case since the MCO CR did not set the nodeSelector")
+		}
+
 		By("Checking node selector for all pods")
 		Eventually(func() error {
-			err = utils.CheckAllPodNodeSelector(testOptions)
+			err = utils.CheckAllPodNodeSelector(testOptions, spec["nodeSelector"].(map[string]interface{}))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: hchenxa <huichen@redhat.com>

2 problem here:
1). the nodeSelector can be customized in the MCO CR, so if the nodeSelector did not set in the CR, we should skip the check.
2). the current key and value was hardcode, so the cases will be failed if the MCO CR have different value set.

Proposal:
1). before start the test, check if the MCO have nodeSelector set in the CR, if not, skip the test
2). when comparing the key and value, get the nodeSelector key and value from MCO CR and use this key and value to compare the nodeSelector in pod spec. 