### PR TITLE
print managedcluster status

### DIFF
--- a/pkg/tests/observability_addon_test.go
+++ b/pkg/tests/observability_addon_test.go
@@ -228,9 +228,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_alert_test.go
+++ b/pkg/tests/observability_alert_test.go
@@ -219,9 +219,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_cert_renew_test.go
+++ b/pkg/tests/observability_cert_renew_test.go
@@ -134,9 +134,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_custom_dashboards_test.go
+++ b/pkg/tests/observability_custom_dashboards_test.go
@@ -67,9 +67,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_default_config_test.go
+++ b/pkg/tests/observability_default_config_test.go
@@ -82,9 +82,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_endpoint_preserve_test.go
+++ b/pkg/tests/observability_endpoint_preserve_test.go
@@ -142,9 +142,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_grafana_dev_test.go
+++ b/pkg/tests/observability_grafana_dev_test.go
@@ -32,9 +32,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_grafana_test.go
+++ b/pkg/tests/observability_grafana_test.go
@@ -33,9 +33,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_manifestwork_test.go
+++ b/pkg/tests/observability_manifestwork_test.go
@@ -98,9 +98,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_metricslist_test.go
+++ b/pkg/tests/observability_metricslist_test.go
@@ -67,9 +67,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_observatorium_preserve_test.go
+++ b/pkg/tests/observability_observatorium_preserve_test.go
@@ -72,9 +72,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -213,9 +213,7 @@ var _ = Describe("Observability:", func() {
 	AfterEach(func() {
 		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/tests/observability_retention_test.go
+++ b/pkg/tests/observability_retention_test.go
@@ -114,9 +114,7 @@ var _ = Describe("Observability:", func() {
 
 	AfterEach(func() {
 		if testFailed {
-			utils.PrintMCOObject(testOptions)
-			utils.PrintAllMCOPodsStatus(testOptions)
-			utils.PrintAllOBAPodsStatus(testOptions)
+			utils.PrintMCORelatedInfoForDebug(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}

--- a/pkg/utils/mco_managedcluster.go
+++ b/pkg/utils/mco_managedcluster.go
@@ -3,7 +3,10 @@
 
 package utils
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
 
 func UpdateObservabilityFromManagedCluster(opt TestOptions, enableObservability bool) error {
 	clusterName := GetManagedClusterName(opt)
@@ -30,4 +33,18 @@ func UpdateObservabilityFromManagedCluster(opt TestOptions, enableObservability 
 		}
 	}
 	return nil
+}
+
+func PrintManagedCluster(opt TestOptions) {
+	clusterName := GetManagedClusterName(opt)
+	if clusterName != "" {
+		clientDynamic := GetKubeClientDynamic(opt, true)
+		cluster, err := clientDynamic.Resource(NewOCMManagedClustersGVR()).Get(clusterName, metav1.GetOptions{})
+		if err != nil {
+			klog.Errorf("Failed to get managedcluster %+v: %v", clusterName, err)
+			return
+		}
+		klog.V(1).Infof("managedcluster <%v>: %+v\n", clusterName, cluster)
+	}
+	klog.Errorf("Failed to found managedcluster")
 }

--- a/pkg/utils/mco_managedcluster.go
+++ b/pkg/utils/mco_managedcluster.go
@@ -46,5 +46,4 @@ func PrintManagedCluster(opt TestOptions) {
 		}
 		klog.V(1).Infof("managedcluster <%v>: %+v\n", clusterName, cluster)
 	}
-	klog.Errorf("Failed to found managedcluster")
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -639,3 +639,10 @@ func IsOpenshift(client *rest.RESTClient) bool {
 func IntegrityChecking(opt TestOptions) error {
 	return CheckMCOComponentsInHighMode(opt)
 }
+
+func PrintMCORelatedInfoForDebug(opt TestOptions) {
+	PrintMCOObject(opt)
+	PrintAllMCOPodsStatus(opt)
+	PrintAllOBAPodsStatus(opt)
+	PrintManagedCluster(opt)
+}


### PR DESCRIPTION
if managedcluster not ready, the e2e test will be failed, so we can print managedcluster for debugging.

Signed-off-by: Song Song Li <ssli@redhat.com>