### PR TITLE
remove the hardcoded namespace when get the mco pods

### DIFF
--- a/pkg/tests/observability_install_test.go
+++ b/pkg/tests/observability_install_test.go
@@ -32,7 +32,7 @@ func installMCO() {
 		testOptions.HubCluster.KubeContext)
 
 	By("Checking MCO operator is existed")
-	podList, err := hubClient.CoreV1().Pods(MCO_OPERATOR_NAMESPACE).List(metav1.ListOptions{LabelSelector: MCO_LABEL})
+	podList, err := hubClient.CoreV1().Pods("").List(metav1.ListOptions{LabelSelector: MCO_LABEL})
 	Expect(len(podList.Items)).To(Equal(1))
 	Expect(err).NotTo(HaveOccurred())
 	mcoPod := ""

--- a/pkg/tests/observability_install_test.go
+++ b/pkg/tests/observability_install_test.go
@@ -35,9 +35,13 @@ func installMCO() {
 	podList, err := hubClient.CoreV1().Pods("").List(metav1.ListOptions{LabelSelector: MCO_LABEL})
 	Expect(len(podList.Items)).To(Equal(1))
 	Expect(err).NotTo(HaveOccurred())
-	mcoPod := ""
+	var (
+		mcoPod = ""
+		mcoNs  = ""
+	)
 	for _, pod := range podList.Items {
 		mcoPod = pod.GetName()
+		mcoNs = pod.GetNamespace()
 		Expect(string(mcoPod)).NotTo(Equal(""))
 		Expect(string(pod.Status.Phase)).To(Equal("Running"))
 	}
@@ -51,7 +55,7 @@ func installMCO() {
 		} else {
 			fmt.Fprintf(GinkgoWriter, "[DEBUG] MCO is installed successfully!\n")
 		}
-	}(testOptions, false, MCO_OPERATOR_NAMESPACE, mcoPod, "multicluster-observability-operator", false, 1000)
+	}(testOptions, false, mcoNs, mcoPod, "multicluster-observability-operator", false, 1000)
 
 	By("Checking Required CRDs is existed")
 	Eventually(func() error {
@@ -65,7 +69,7 @@ func installMCO() {
 
 	Expect(utils.CreateMCONamespace(testOptions)).NotTo(HaveOccurred())
 	if os.Getenv("IS_CANARY_ENV") == "true" {
-		Expect(utils.CreatePullSecret(testOptions)).NotTo(HaveOccurred())
+		Expect(utils.CreatePullSecret(testOptions, mcoNs)).NotTo(HaveOccurred())
 		Expect(utils.CreateObjSecret(testOptions)).NotTo(HaveOccurred())
 	}
 	//set resource quota and limit range for canary environment to avoid destruct the node

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -17,12 +17,11 @@ import (
 )
 
 const (
-	MCO_OPERATOR_NAMESPACE = "open-cluster-management"
-	MCO_CR_NAME            = "observability"
-	MCO_NAMESPACE          = "open-cluster-management-observability"
-	MCO_ADDON_NAMESPACE    = "open-cluster-management-addon-observability"
-	MCO_LABEL              = "name=multicluster-observability-operator"
-	MCO_LABEL_OWNER        = "owner=multicluster-observability-operator"
+	MCO_CR_NAME         = "observability"
+	MCO_NAMESPACE       = "open-cluster-management-observability"
+	MCO_ADDON_NAMESPACE = "open-cluster-management-addon-observability"
+	MCO_LABEL           = "name=multicluster-observability-operator"
+	MCO_LABEL_OWNER     = "owner=multicluster-observability-operator"
 )
 
 var (

--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	MCO_OPERATOR_NAMESPACE        = "open-cluster-management"
 	MCO_CR_NAME                   = "observability"
 	MCO_COMPONENT_LABEL           = "observability.open-cluster-management.io/name=" + MCO_CR_NAME
 	OBSERVATORIUM_COMPONENT_LABEL = "app.kubernetes.io/part-of=observatorium"
@@ -791,14 +790,14 @@ func CheckMCOConversion(opt TestOptions, v1beta1tov1beta2GoldenPath string) erro
 	return nil
 }
 
-func CreatePullSecret(opt TestOptions) error {
+func CreatePullSecret(opt TestOptions, mcoNs string) error {
 	clientKube := NewKubeClient(
 		opt.HubCluster.MasterURL,
 		opt.KubeConfig,
 		opt.HubCluster.KubeContext)
-	namespace := MCO_OPERATOR_NAMESPACE
+
 	name := "multiclusterhub-operator-pull-secret"
-	pullSecret, errGet := clientKube.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	pullSecret, errGet := clientKube.CoreV1().Secrets(mcoNs).Get(name, metav1.GetOptions{})
 	if errGet != nil {
 		return errGet
 	}
@@ -818,7 +817,7 @@ kind: Namespace
 metadata:
   name: %s`,
 		MCO_NAMESPACE)
-	klog.V(1).Infof("Create MCO namespaces")
+	klog.V(1).Infof("Create %s namespaces", MCO_NAMESPACE)
 	return Apply(
 		opt.HubCluster.MasterURL,
 		opt.KubeConfig,


### PR DESCRIPTION
Signed-off-by: hchenxa <huichen@redhat.com>

since the mco operator may be installed in any of cluster, so we should not hardcode the namespace when get the mco operators pods.