### PR TITLE
update retentionConfig in advanced

### DIFF
--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -555,7 +555,8 @@ func ModifyMCOCR(opt TestOptions) error {
 		return getErr
 	}
 	spec := mco.Object["spec"].(map[string]interface{})
-	retentionConfig := spec["retentionConfig"].(map[string]interface{})
+	advanced := spec["advanced"].(map[string]interface{})
+	retentionConfig := advanced["retentionConfig"].(map[string]interface{})
 	retentionConfig["retentionResolutionRaw"] = "3d"
 	storageConfig := spec["storageConfig"].(map[string]interface{})
 	storageConfig["alertmanagerStorageSize"] = "2Gi"


### PR DESCRIPTION
Move `retentionConfig` into `advanced` section in this PR - https://github.com/open-cluster-management/multicluster-observability-operator/pull/553

Signed-off-by: clyang82 <chuyang@redhat.com>