### PR TITLE
get the mch namespace when create the pullsecret

### DIFF
--- a/pkg/tests/observability_install_test.go
+++ b/pkg/tests/observability_install_test.go
@@ -27,10 +27,12 @@ func installMCO() {
 		testOptions.HubCluster.KubeContext)
 
 	By("Checking MCO operator is existed")
-	podList, err := hubClient.CoreV1().Pods(MCO_OPERATOR_NAMESPACE).List(metav1.ListOptions{LabelSelector: MCO_LABEL})
+	podList, err := hubClient.CoreV1().Pods("").List(metav1.ListOptions{LabelSelector: MCO_LABEL})
 	Expect(len(podList.Items)).To(Equal(1))
 	Expect(err).NotTo(HaveOccurred())
+	mcoNs := ""
 	for _, pod := range podList.Items {
+		mcoNs = pod.GetNamespace()
 		Expect(string(pod.Status.Phase)).To(Equal("Running"))
 	}
 
@@ -45,7 +47,7 @@ func installMCO() {
 	}).Should(Succeed())
 
 	Expect(utils.CreateMCONamespace(testOptions)).NotTo(HaveOccurred())
-	Expect(utils.CreatePullSecret(testOptions)).NotTo(HaveOccurred())
+	Expect(utils.CreatePullSecret(testOptions, mcoNs)).NotTo(HaveOccurred())
 	Expect(utils.CreateObjSecret(testOptions)).NotTo(HaveOccurred())
 	//set resource quota and limit range for canary environment to avoid destruct the node
 	yamlB, err := kustomize.Render(kustomize.Options{KustomizationPath: "../../observability-gitops/policy"})

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -14,12 +14,11 @@ import (
 )
 
 const (
-	MCO_OPERATOR_NAMESPACE = "open-cluster-management"
-	MCO_CR_NAME            = "observability"
-	MCO_NAMESPACE          = "open-cluster-management-observability"
-	MCO_ADDON_NAMESPACE    = "open-cluster-management-addon-observability"
-	MCO_LABEL              = "name=multicluster-observability-operator"
-	MCO_LABEL_OWNER        = "owner=multicluster-observability-operator"
+	MCO_CR_NAME         = "observability"
+	MCO_NAMESPACE       = "open-cluster-management-observability"
+	MCO_ADDON_NAMESPACE = "open-cluster-management-addon-observability"
+	MCO_LABEL           = "name=multicluster-observability-operator"
+	MCO_LABEL_OWNER     = "owner=multicluster-observability-operator"
 )
 
 var (

--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	MCO_OPERATOR_NAMESPACE        = "open-cluster-management"
 	MCO_CR_NAME                   = "observability"
 	MCO_COMPONENT_LABEL           = "observability.open-cluster-management.io/name=" + MCO_CR_NAME
 	OBSERVATORIUM_COMPONENT_LABEL = "app.kubernetes.io/part-of=observatorium"
@@ -566,14 +565,13 @@ func DeleteMCOInstance(opt TestOptions) error {
 	return clientDynamic.Resource(NewMCOGVR()).Delete("observability", &metav1.DeleteOptions{})
 }
 
-func CreatePullSecret(opt TestOptions) error {
+func CreatePullSecret(opt TestOptions, mcoNs string) error {
 	clientKube := NewKubeClient(
 		opt.HubCluster.MasterURL,
 		opt.KubeConfig,
 		opt.HubCluster.KubeContext)
-	namespace := MCO_OPERATOR_NAMESPACE
 	name := "multiclusterhub-operator-pull-secret"
-	pullSecret, errGet := clientKube.CoreV1().Secrets(namespace).Get(name, metav1.GetOptions{})
+	pullSecret, errGet := clientKube.CoreV1().Secrets(mcoNs).Get(name, metav1.GetOptions{})
 	if errGet != nil {
 		return errGet
 	}


### PR DESCRIPTION
Signed-off-by: hchenxa <huichen@redhat.com>

The PR was update the namespace to handle the e2e test in zstream of release-2.2