### PR TITLE
only show debug msg when current case failed

### DIFF
--- a/cicd-scripts/setup-e2e-tests.sh
+++ b/cicd-scripts/setup-e2e-tests.sh
@@ -139,6 +139,7 @@ deploy_hub_spoke_core() {
     latest_release_branch=$(git ls-remote --heads https://github.com/open-cluster-management/registration-operator.git release\* | tail -1 | cut -f 2 | cut -d '/' -f 3)
     git clone --depth 1 -b ${latest_release_branch} https://github.com/open-cluster-management/registration-operator.git && cd registration-operator
 
+    export HUB_KUBECONFIG=${KUBECONFIG}
     # deploy hub and spoke via OLM
     make deploy
 

--- a/pkg/tests/observability_addon_test.go
+++ b/pkg/tests/observability_addon_test.go
@@ -226,8 +226,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
@@ -235,5 +234,6 @@ var _ = Describe("Observability:", func() {
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_advanced_config_test.go
+++ b/pkg/tests/observability_advanced_config_test.go
@@ -142,13 +142,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_alert_test.go
+++ b/pkg/tests/observability_alert_test.go
@@ -216,13 +216,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_cert_renew_test.go
+++ b/pkg/tests/observability_cert_renew_test.go
@@ -140,13 +140,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_custom_dashboards_test.go
+++ b/pkg/tests/observability_custom_dashboards_test.go
@@ -65,13 +65,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_default_config_test.go
+++ b/pkg/tests/observability_default_config_test.go
@@ -80,13 +80,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_endpoint_preserve_test.go
+++ b/pkg/tests/observability_endpoint_preserve_test.go
@@ -140,13 +140,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_grafana_dev_test.go
+++ b/pkg/tests/observability_grafana_dev_test.go
@@ -32,13 +32,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_grafana_test.go
+++ b/pkg/tests/observability_grafana_test.go
@@ -31,13 +31,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_manifestwork_test.go
+++ b/pkg/tests/observability_manifestwork_test.go
@@ -96,13 +96,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_metricslist_test.go
+++ b/pkg/tests/observability_metricslist_test.go
@@ -73,13 +73,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_observatorium_preserve_test.go
+++ b/pkg/tests/observability_observatorium_preserve_test.go
@@ -70,13 +70,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -174,13 +174,13 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)
 		} else {
 			Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
 		}
+		testFailed = testFailed || CurrentGinkgoTestDescription().Failed
 	})
 })

--- a/pkg/tests/observability_retention_test.go
+++ b/pkg/tests/observability_retention_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Observability:", func() {
 	})
 
 	AfterEach(func() {
-		if testFailed {
+		if CurrentGinkgoTestDescription().Failed {
 			utils.PrintMCOObject(testOptions)
 			utils.PrintAllMCOPodsStatus(testOptions)
 			utils.PrintAllOBAPodsStatus(testOptions)


### PR DESCRIPTION
currently, we print all debug msg in every test case. even if the current case runs successfully. so we just need to show debug msg when the case failed.

Signed-off-by: Song Song Li <ssli@redhat.com>