### PR TITLE
Expect has timeout

### DIFF
--- a/pkg/tests/observability_grafana_dev_test.go
+++ b/pkg/tests/observability_grafana_dev_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/klog"
 
 	"github.com/open-cluster-management/observability-e2e-test/pkg/utils"
 )
@@ -21,7 +22,11 @@ var _ = Describe("Observability:", func() {
 		cmd := exec.Command("../../cicd-scripts/grafana-dev-test.sh")
 		var out bytes.Buffer
 		cmd.Stdout = &out
-		Expect(cmd.Run()).NotTo(HaveOccurred())
+		err := cmd.Run()
+		if err != nil {
+			klog.V(1).Infof("Failed to run grafana-dev-test.sh: %v", out.String())
+		}
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
We may meet Throttling during testing. Put `cmd.Run()` as arg of `Expect` is easy to timeout.

```
I0621 08:16:37.604198   10840 request.go:655] Throttling request took 1.165490291s, request: GET:https://api.ci-op-5r140n4g-7ee79.origin-ci-int-aws.dev.rhcloud.com:6443/apis/batch/v1beta1?timeout=32s
I0621 08:16:47.804184   10840 request.go:655] Throttling request took 11.365388486s, request: GET:https://api.ci-op-5r140n4g-7ee79.origin-ci-int-aws.dev.rhcloud.com:6443/apis/k8s.cni.cncf.io/v1?timeout=32s
deployment.apps "grafana-dev" deleted
I0621 08:16:55.345390   10859 request.go:655] Throttling request took 1.173074209s, request: GET:https://api.ci-op-5r140n4g-7ee79.origin-ci-int-aws.dev.rhcloud.com:6443/apis/networking.k8s.io/v1?timeout=32s
I0621 08:17:05.545378   10859 request.go:655] Throttling request took 11.372972636s, request: GET:https://api.ci-op-5r140n4g-7ee79.origin-ci-int-aws.dev.rhcloud.com:6443/apis/user.openshift.io/v1?timeout=32s

```

Signed-off-by: clyang82 <chuyang@redhat.com>