### PR TITLE
skip the cases when MCO was customized installation

### DIFF
--- a/pkg/tests/observability_default_config_test.go
+++ b/pkg/tests/observability_default_config_test.go
@@ -5,6 +5,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -28,6 +29,9 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P1][Sev1][Observability][Stable] Checking metrics default values on managed cluster (config/g0)", func() {
+		if os.Getenv("SKIP_INSTALL_STEP") == "true" {
+			Skip("Skip the case due to MCO CR was created customized")
+		}
 		mcoRes, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
 		if err != nil {
 			panic(err.Error())
@@ -38,13 +42,16 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P1][Sev1][Observability][Stable] Checking default value of PVC and StorageClass (config/g0)", func() {
+		if os.Getenv("SKIP_INSTALL_STEP") == "true" {
+			Skip("Skip the case due to MCO CR was created customized")
+		}
 		mcoSC, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		spec := mcoSC.Object["spec"].(map[string]interface{})
 		scInCR := spec["storageConfig"].(map[string]interface{})["storageClass"].(string)
 
-		scList, err := hubClient.StorageV1().StorageClasses().List(metav1.ListOptions{})
+		scList, _ := hubClient.StorageV1().StorageClasses().List(metav1.ListOptions{})
 		scMatch := false
 		defaultSC := ""
 		for _, sc := range scList.Items {

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -53,6 +53,16 @@ var _ = Describe("Observability:", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Waiting for MCO retentionResolutionRaw filed to take effect")
+		mcoCR, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if _, adv := mcoCR.Object["spec"].(map[string]interface{})["advanced"]; !adv {
+			Skip("Skip the case since the MCO CR did not have advanced spec configed")
+		} else {
+			if _, rec := mcoCR.Object["spec"].(map[string]interface{})["advanced"].(map[string]interface{})["retentionConfig"]; !rec {
+				Skip("Skip the case since the MCO CR did not have advanced retentionConfig configed")
+			}
+		}
+
 		Eventually(func() error {
 			name := MCO_CR_NAME + "-thanos-compact"
 			compact, err := hubClient.AppsV1().StatefulSets(MCO_NAMESPACE).Get(name, metav1.GetOptions{})
@@ -138,6 +148,7 @@ var _ = Describe("Observability:", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Waiting for MCO retentionResolutionRaw filed to take effect")
+
 		Eventually(func() error {
 			name := MCO_CR_NAME + "-thanos-compact"
 			compact, err := hubClient.AppsV1().StatefulSets(MCO_NAMESPACE).Get(name, metav1.GetOptions{})

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Observability:", func() {
 		By("Waiting for MCO retentionResolutionRaw filed to take effect")
 		advRetentionCon, err := utils.CheckAdvRetentionConfig(testOptions)
 		if !advRetentionCon {
-			Skip("Skip the case since" + err.Error())
+			Skip("Skip the case since " + err.Error())
 		}
 
 		Eventually(func() error {
@@ -139,7 +139,7 @@ var _ = Describe("Observability:", func() {
 	It("[P2][Sev2][Observability][Stable] Revert MCO CR changes (reconcile/g0)", func() {
 		advRetentionCon, err := utils.CheckAdvRetentionConfig(testOptions)
 		if !advRetentionCon {
-			Skip("Skip the case since" + err.Error())
+			Skip("Skip the case since " + err.Error())
 		}
 
 		By("Revert MCO CR changes")

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -142,9 +142,17 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P2][Sev2][Observability][Stable] Revert MCO CR changes (reconcile/g0)", func() {
-
+		mcoCR, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if _, adv := mcoCR.Object["spec"].(map[string]interface{})["advanced"]; !adv {
+			Skip("Skip the case since the MCO CR did not have advanced spec configed")
+		} else {
+			if _, rec := mcoCR.Object["spec"].(map[string]interface{})["advanced"].(map[string]interface{})["retentionConfig"]; !rec {
+				Skip("Skip the case since the MCO CR did not have advanced retentionConfig configed")
+			}
+		}
 		By("Revert MCO CR changes")
-		err := utils.RevertMCOCRModification(testOptions)
+		err = utils.RevertMCOCRModification(testOptions)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Waiting for MCO retentionResolutionRaw filed to take effect")

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -53,14 +53,9 @@ var _ = Describe("Observability:", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Waiting for MCO retentionResolutionRaw filed to take effect")
-		mcoCR, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		if _, adv := mcoCR.Object["spec"].(map[string]interface{})["advanced"]; !adv {
-			Skip("Skip the case since the MCO CR did not have advanced spec configed")
-		} else {
-			if _, rec := mcoCR.Object["spec"].(map[string]interface{})["advanced"].(map[string]interface{})["retentionConfig"]; !rec {
-				Skip("Skip the case since the MCO CR did not have advanced retentionConfig configed")
-			}
+		advRetentionCon, err := utils.CheckAdvRetentionConfig(testOptions)
+		if !advRetentionCon {
+			Skip("Skip the case since" + err.Error())
 		}
 
 		Eventually(func() error {
@@ -142,15 +137,11 @@ var _ = Describe("Observability:", func() {
 	})
 
 	It("[P2][Sev2][Observability][Stable] Revert MCO CR changes (reconcile/g0)", func() {
-		mcoCR, err := dynClient.Resource(utils.NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		if _, adv := mcoCR.Object["spec"].(map[string]interface{})["advanced"]; !adv {
-			Skip("Skip the case since the MCO CR did not have advanced spec configed")
-		} else {
-			if _, rec := mcoCR.Object["spec"].(map[string]interface{})["advanced"].(map[string]interface{})["retentionConfig"]; !rec {
-				Skip("Skip the case since the MCO CR did not have advanced retentionConfig configed")
-			}
+		advRetentionCon, err := utils.CheckAdvRetentionConfig(testOptions)
+		if !advRetentionCon {
+			Skip("Skip the case since" + err.Error())
 		}
+
 		By("Revert MCO CR changes")
 		err = utils.RevertMCOCRModification(testOptions)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -579,12 +579,18 @@ func ModifyMCOCR(opt TestOptions) error {
 	if getErr != nil {
 		return getErr
 	}
+
 	spec := mco.Object["spec"].(map[string]interface{})
-	advanced := spec["advanced"].(map[string]interface{})
-	retentionConfig := advanced["retentionConfig"].(map[string]interface{})
-	retentionConfig["retentionResolutionRaw"] = "3d"
 	storageConfig := spec["storageConfig"].(map[string]interface{})
 	storageConfig["alertmanagerStorageSize"] = "2Gi"
+
+	if _, adv := spec["advanced"]; adv {
+		advanced := spec["advanced"].(map[string]interface{})
+		if _, rec := advanced["retentionConfig"]; rec {
+			retentionConfig := advanced["retentionConfig"].(map[string]interface{})
+			retentionConfig["retentionResolutionRaw"] = "3d"
+		}
+	}
 
 	_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(mco, metav1.UpdateOptions{})
 	if updateErr != nil {

--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -584,12 +584,10 @@ func ModifyMCOCR(opt TestOptions) error {
 	storageConfig := spec["storageConfig"].(map[string]interface{})
 	storageConfig["alertmanagerStorageSize"] = "2Gi"
 
-	if _, adv := spec["advanced"]; adv {
-		advanced := spec["advanced"].(map[string]interface{})
-		if _, rec := advanced["retentionConfig"]; rec {
-			retentionConfig := advanced["retentionConfig"].(map[string]interface{})
-			retentionConfig["retentionResolutionRaw"] = "3d"
-		}
+	advRetentionCon, _ := CheckAdvRetentionConfig(opt)
+	if advRetentionCon {
+		retentionConfig := spec["advanced"].(map[string]interface{})["retentionConfig"].(map[string]interface{})
+		retentionConfig["retentionResolutionRaw"] = "3d"
 	}
 
 	_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(mco, metav1.UpdateOptions{})
@@ -597,6 +595,29 @@ func ModifyMCOCR(opt TestOptions) error {
 		return updateErr
 	}
 	return nil
+}
+
+func CheckAdvRetentionConfig(opt TestOptions) (bool, error) {
+	clientDynamic := NewKubeClientDynamic(
+		opt.HubCluster.MasterURL,
+		opt.KubeConfig,
+		opt.HubCluster.KubeContext)
+	mco, getErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Get(MCO_CR_NAME, metav1.GetOptions{})
+	if getErr != nil {
+		return false, getErr
+	}
+
+	spec := mco.Object["spec"].(map[string]interface{})
+	if _, adv := spec["advanced"]; !adv {
+		return false, fmt.Errorf("the MCO CR did not have advanced spec configed")
+	} else {
+		advanced := spec["advanced"].(map[string]interface{})
+		if _, rec := advanced["retentionConfig"]; !rec {
+			return false, fmt.Errorf("the MCO CR did not have advanced retentionConfig spec configed")
+		} else {
+			return true, nil
+		}
+	}
 }
 
 // RevertMCOCRModification revert the previous changes
@@ -610,9 +631,11 @@ func RevertMCOCRModification(opt TestOptions) error {
 		return getErr
 	}
 	spec := mco.Object["spec"].(map[string]interface{})
-	advanced := spec["advanced"].(map[string]interface{})
-	retentionConfig := advanced["retentionConfig"].(map[string]interface{})
-	retentionConfig["retentionResolutionRaw"] = "5d"
+	advRetentionCon, _ := CheckAdvRetentionConfig(opt)
+	if advRetentionCon {
+		retentionConfig := spec["advanced"].(map[string]interface{})["retentionConfig"].(map[string]interface{})
+		retentionConfig["retentionResolutionRaw"] = "5d"
+	}
 
 	_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(mco, metav1.UpdateOptions{})
 	if updateErr != nil {
@@ -711,7 +734,11 @@ func ModifyMCORetentionResolutionRaw(opt TestOptions) error {
 	}
 
 	spec := mco.Object["spec"].(map[string]interface{})
-	spec["retentionResolutionRaw"] = "3d"
+	advRetentionCon, _ := CheckAdvRetentionConfig(opt)
+	if advRetentionCon {
+		retentionConfig := spec["advanced"].(map[string]interface{})["retentionConfig"].(map[string]interface{})
+		retentionConfig["retentionResolutionRaw"] = "3d"
+	}
 	_, updateErr := clientDynamic.Resource(NewMCOGVRV1BETA2()).Update(mco, metav1.UpdateOptions{})
 	if updateErr != nil {
 		return updateErr


### PR DESCRIPTION
Signed-off-by: hchenxa <huichen@redhat.com>

1. if the MCO was created and already exists, no need to check the default value.
2. if the MCO CR did not have retentionConfig, update MCO will throws null point exception, so in this case, only update the storage size and test this part.