### PR TITLE
Ensure the sts or deployment created

### DIFF
--- a/pkg/utils/mco_deploy.go
+++ b/pkg/utils/mco_deploy.go
@@ -362,6 +362,10 @@ func CheckMCOComponents(opt TestOptions) error {
 			return err
 		}
 
+		if len((*deployList).Items) == 0 {
+			return fmt.Errorf("should have deployment created with label %s", deploymentLabel)
+		}
+
 		for _, deployInfo := range (*deployList).Items {
 			if deployInfo.Status.ReadyReplicas != *deployInfo.Spec.Replicas {
 				err = fmt.Errorf("deployment %s should have %d but got %d ready replicas",
@@ -390,6 +394,10 @@ func CheckMCOComponents(opt TestOptions) error {
 		if err != nil {
 			klog.V(1).Infof("Error while listing deployment with label %s due to: %s", statefulsetLabel, err.Error())
 			return err
+		}
+
+		if len((*statefulsetList).Items) == 0 {
+			return fmt.Errorf("should have statefulset created with label %s", statefulsetLabel)
 		}
 
 		for _, statefulsetInfo := range (*statefulsetList).Items {


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/14308

the problem here we use list with label to get the deployment or statefulset. There has case cannot list the statefulset or deployment with the expected label. there is no error returned. 

for the canary test, we can find the test case is running before `Deployment observability-grafana is not ready`.

Signed-off-by: clyang82 <chuyang@redhat.com>