### PR TITLE
add timeout for alertmgr

### DIFF
--- a/pkg/tests/observability_addon_test.go
+++ b/pkg/tests/observability_addon_test.go
@@ -226,7 +226,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_alert_test.go
+++ b/pkg/tests/observability_alert_test.go
@@ -240,7 +240,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_cert_renew_test.go
+++ b/pkg/tests/observability_cert_renew_test.go
@@ -144,7 +144,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_custom_dashboards_test.go
+++ b/pkg/tests/observability_custom_dashboards_test.go
@@ -65,7 +65,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_default_config_test.go
+++ b/pkg/tests/observability_default_config_test.go
@@ -87,7 +87,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_endpoint_preserve_test.go
+++ b/pkg/tests/observability_endpoint_preserve_test.go
@@ -140,7 +140,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_grafana_test.go
+++ b/pkg/tests/observability_grafana_test.go
@@ -31,7 +31,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_manifestwork_test.go
+++ b/pkg/tests/observability_manifestwork_test.go
@@ -96,7 +96,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_metricslist_test.go
+++ b/pkg/tests/observability_metricslist_test.go
@@ -73,7 +73,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_observatorium_preserve_test.go
+++ b/pkg/tests/observability_observatorium_preserve_test.go
@@ -75,7 +75,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {

--- a/pkg/tests/observability_reconcile_test.go
+++ b/pkg/tests/observability_reconcile_test.go
@@ -196,7 +196,10 @@ var _ = Describe("Observability:", func() {
 	})
 
 	JustAfterEach(func() {
-		Expect(utils.IntegrityChecking(testOptions)).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return utils.IntegrityChecking(testOptions)
+			// alertmanager takes 4 minutes to start, so we need to set a timeout for IntegrityChecking
+		}, EventuallyTimeoutMinute*5, EventuallyIntervalSecond*5).Should(Succeed())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
alertmanager takes 4 minutes to start, so we need to set a timeout for `IntegrityChecking`
Signed-off-by: Song Song Li <ssli@redhat.com>